### PR TITLE
feat(recupera-landing): copy alineado con campaña Google Ads + SEO + llms.txt

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,22 +11,22 @@ import './globals.css'
 import Providers from './providers'
 
 export const metadata: Metadata = {
-  title: 'Recupera - El mejor CRM de cobranza y pagos B2B',
+  title: 'Recupera - Cobranza Online B2B Chile | Pagas Solo Si Recuperamos',
   description:
-    'Optimiza tu gestión de cobranza y pagos de facturas con Recupera, el CRM B2B que simplifica procesos, mejora la eficiencia y acelera tus ingresos.',
+    'Cobranza B2B con publicación DICOM en Chile. Solo pagas si recuperamos tu cartera vencida o facturas impagas. 85% de recupero promedio. Respaldados por Recsa.',
   keywords:
-    'CRM cobranza, pagos B2B, facturación, gestión de pagos, CRM empresas, automatización de cobranza, Recupera',
+    'cobranza online, cobrar facturas vencidas, facturas impagas, cobranza b2b chile, publicacion dicom, recuperar cartera vencida, externalizar cobranza b2b, servicio de cobranza empresas',
   authors: [{ name: 'Recupera' }],
   robots: { index: true, follow: true },
   openGraph: {
-    title: 'Recupera - El mejor CRM de cobranza y pagos B2B',
+    title: 'Recupera - Cobranza B2B | Pagas Solo Si Recuperamos',
     description:
-      'Con Recupera, simplifica y acelera la gestión de tus cobros y pagos. Una solución para empresas enfocada en eficiencia y resultados.',
+      'Solo pagas si recuperamos. Cobranza B2B con publicación DICOM en Chile. 85% de recupero promedio. Sin riesgo para tu empresa.',
     type: 'website',
     url: 'https://recupera.somossena.com',
     images: ['https://recupera.somossena.com/sena-crm-lite.jpg'],
     siteName: 'Recupera',
-    locale: 'es_PE',
+    locale: 'es_CL',
   },
   other: {
     'facebook-domain-verification': 'tyjmxihsgkrx666ql4rwmnhsftl6hv',
@@ -58,6 +58,55 @@ export default async function RootLayout({
                           f.parentNode.insertBefore(j,f);
                           })(window,document,'script','dataLayer','GTM-T2QDCJ6C');
                           `}
+          </Script>
+          {/* FAQ Schema */}
+          <Script id="faq-schema" type="application/ld+json" strategy="beforeInteractive">
+            {JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'FAQPage',
+              mainEntity: [
+                {
+                  '@type': 'Question',
+                  name: '¿Cuánto toma ver resultados?',
+                  acceptedAnswer: {
+                    '@type': 'Answer',
+                    text: 'Primeros contactos en 48-72h. Acuerdos típicamente en 2 semanas.',
+                  },
+                },
+                {
+                  '@type': 'Question',
+                  name: '¿Qué pasa si no recuperan nada?',
+                  acceptedAnswer: {
+                    '@type': 'Answer',
+                    text: 'No pagas nada. Modelo 100% contingente: solo cobramos un porcentaje sobre el monto efectivamente recuperado.',
+                  },
+                },
+                {
+                  '@type': 'Question',
+                  name: '¿Se preservan las relaciones comerciales?',
+                  acceptedAnswer: {
+                    '@type': 'Answer',
+                    text: 'Sí. Nuestro enfoque profesional preserva los vínculos comerciales. 40 años de experiencia Recsa en gestión de cobranza B2B.',
+                  },
+                },
+                {
+                  '@type': 'Question',
+                  name: '¿Con qué tipo de cartera trabajan?',
+                  acceptedAnswer: {
+                    '@type': 'Answer',
+                    text: 'Trabajamos con cartera vencida de +60 días, incluyendo facturas impagas y cuentas por cobrar B2B. Para gestión preventiva antes del vencimiento, tenemos otra solución — consultanos.',
+                  },
+                },
+                {
+                  '@type': 'Question',
+                  name: '¿En qué países operan?',
+                  acceptedAnswer: {
+                    '@type': 'Answer',
+                    text: '15 países en LATAM: Chile, Perú, Colombia, México, Argentina, Brasil, y más. Presencia local con conocimiento del mercado en cada país.',
+                  },
+                },
+              ],
+            })}
           </Script>
           {/* Google Ads */}
           <Script

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  const content = `# Recupera — Cobranza B2B con publicación DICOM
+
+> Servicio de recuperación de cartera vencida para empresas B2B en Chile y LATAM.
+> Solo pagas si recuperamos. Sin costo fijo, sin riesgo.
+
+## Qué hace Recupera
+
+Recupera gestiona la cobranza de facturas impagas y cartera vencida B2B mediante:
+- Gestión preventiva antes de la mora
+- Publicación en registros de morosidad (DICOM, Boletín Comercial)
+- Gestión post-publicación hasta el cobro efectivo
+
+No realizamos gestión judicial. Todo el proceso es externo a los tribunales.
+
+## Modelo de negocio
+
+- Sin costo de evaluación
+- Sin setup ni mensualidad
+- Comisión solo sobre el monto efectivamente recuperado
+- Si no recuperamos, no pagas nada
+
+## Métricas clave
+
+- 85% de tasa de recupero promedio
+- Primeros contactos en 48-72h
+- Acuerdos típicamente en 2 semanas
+- Presencia en 15 países de LATAM
+
+## A quién va dirigido
+
+Empresas B2B con:
+- Cartera vencida de +60 días
+- Facturas impagas que no responden a gestión interna
+- Necesidad de externalizar cobranza sin riesgo financiero
+- Operación en Chile, Perú y otros países de LATAM
+
+## Respaldo institucional
+
+Recupera está respaldado por Recsa, líder en cobranza LATAM con más de 40 años de experiencia,
+operando en 15 países, con 146M de gestiones mensuales y 70M de llamadas de agentes.
+
+## Páginas principales
+
+- [Inicio](https://recupera.somossena.com): propuesta de valor, modelo contingente, cómo funciona
+- [Precios](https://recupera.somossena.com#precios): detalle del modelo de contingencia
+- [Casos de uso](https://recupera.somossena.com#casos-uso): tipos de cartera que gestionamos
+- [Contacto](https://recupera.somossena.com#contacto): evaluación gratuita de cartera
+
+## Contacto
+
+Web: https://recupera.somossena.com
+Empresa: Sena — somossena.com
+`.trim()
+
+  return new NextResponse(content, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  })
+}

--- a/src/ui/layout/Header.tsx
+++ b/src/ui/layout/Header.tsx
@@ -371,8 +371,8 @@ export const Header = ({ variant }: Props) => {
       },
       {
         id: 2,
-        name: 'Servicio de Recupero',
-        description: 'Gestión humana + estrategia para recuperar cartera.',
+        name: 'Recupera',
+        description: 'Gestión de cobranza B2B. Pagas solo si recuperamos.',
         tab: 'recuperacion',
       },
       {

--- a/src/ui/recupera/sections/ContactForm.tsx
+++ b/src/ui/recupera/sections/ContactForm.tsx
@@ -145,7 +145,7 @@ export const ContactForm = () => {
         <div className="flex flex-1">
           <div className="max-w-full text-left">
             <h2 className="text-brand-primary-dark text-3xl md:text-6xl font-extrabold leading-tight">
-              Estás a un paso de cobrar <span className="text-brand-primary font-caslon">mejor</span>
+              Evalúa tu cartera gratis. <span className="text-brand-primary font-caslon">Sin compromiso.</span>
               <span className="text-brand-secondary font-caslon">.</span>
             </h2>
           </div>

--- a/src/ui/recupera/sections/Credibility.tsx
+++ b/src/ui/recupera/sections/Credibility.tsx
@@ -21,16 +21,11 @@ const stats = [
     label: 'años de experiencia',
     icon: Award,
   },
-  // {
-  //   value: "$XXM",
-  //   label: "recuperados mensualmente",
-  //   icon: DollarSign,
-  // },
-  // {
-  //   value: "XX%",
-  //   label: "tasa promedio de recuperación",
-  //   icon: TrendingUp,
-  // },
+  {
+    value: '85%',
+    label: 'tasa de recupero promedio',
+    icon: TrendingUp,
+  },
 ]
 
 export const Credibility = () => {
@@ -39,14 +34,14 @@ export const Credibility = () => {
       <div className="max-w-[1280px] mx-auto px-4 md:px-12">
         <div className="text-left mb-12">
           <h2 className="text-brand-primary-dark text-3xl md:text-4xl font-extrabold mb-4">
-            Respaldados por el líder en <span className="text-brand-primary">cobranza LATAM</span>
+            Recsa: 40 años recuperando cartera en <span className="text-brand-primary">15 países</span>
           </h2>
           <p className="font-adobe text-black mt-2 text-lg leading-5">
             Recsa lleva más de 40 años recuperando cartera compleja para empresas de todos los tamaños
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {stats.map((stat, index) => {
             const Icon = stat.icon
             return (

--- a/src/ui/recupera/sections/FinalCTA.tsx
+++ b/src/ui/recupera/sections/FinalCTA.tsx
@@ -22,7 +22,7 @@ export const FinalCTA = () => {
       <div className="max-w-[1280px] mx-auto px-4 md:px-12">
         <div className="text-left max-w-3xl mb-12">
           <h2 className="text-brand-primary-dark text-3xl md:text-4xl font-extrabold mb-4">
-            Recupera lo que creías <span className="text-brand-primary">perdido</span>
+            Evaluación gratuita de tu cartera. <span className="text-brand-primary">Resultado en 48h.</span>
           </h2>
           <p className="font-adobe text-black mt-2 text-lg leading-5">
             Sin riesgo. Sin costo inicial. Solo pagas por lo que recuperamos.

--- a/src/ui/recupera/sections/Hero.tsx
+++ b/src/ui/recupera/sections/Hero.tsx
@@ -22,12 +22,12 @@ export const Hero = () => {
       <div className="max-w-[1280px] mx-auto px-4 py-8 md:py-16 md:pt-12 md:pb-8 relative z-10">
         <div className="text-center mx-auto">
           <h1 className="text-brand-primary-dark font-canaro text-3xl md:text-5xl lg:text-7xl font-extrabold leading-tight">
-            Tu cartera vencida no está <span className="text-brand-primary">perdida</span>
+            Recupera tu cartera vencida. <span className="text-brand-primary">Pagas solo si lo logramos.</span>
           </h1>
 
           <p className="text-black text-sm md:text-lg lg:text-xl mb-6 md:mb-8 mt-3 md:mt-4 max-w-3xl mx-auto leading-relaxed">
-            Equipo especializado en recuperación + tecnología avanzada + 40 años de experiencia. Recuperamos
-            sin romper relaciones.
+            Cobranza B2B con publicación DICOM. Sin costo fijo, sin riesgo. Respaldados por Recsa y 40 años
+            de experiencia en Chile y LATAM.
           </p>
 
           <div className="flex flex-col md:flex-row gap-3 md:gap-4 justify-center max-w-md md:max-w-none mx-auto">

--- a/src/ui/recupera/sections/HowItWorks.tsx
+++ b/src/ui/recupera/sections/HowItWorks.tsx
@@ -8,14 +8,14 @@ const steps = [
     icon: FileSearch,
   },
   {
-    title: 'Estrategia Personalizada',
-    description: 'Diseñamos plan de recuperación considerando industria, relación con deudores y objetivos.',
+    title: 'Plan de Recuperación',
+    description: 'Definimos si iniciamos con gestión preventiva, publicación DICOM o gestión post-mora, según el estado de cada cuenta.',
     timeline: '48 horas',
     icon: Lightbulb,
   },
   {
     title: 'Gestión Humana + IA',
-    description: 'Equipo especializado negocia acuerdos de pago manteniendo profesionalismo.',
+    description: 'Nuestro equipo contacta a tus deudores con publicación DICOM cuando corresponde. Preservamos la relación donde es posible.',
     timeline: 'Continuo',
     icon: Users,
   },
@@ -33,7 +33,7 @@ export const HowItWorks = () => {
       <div className="max-w-[1280px] mx-auto px-4 md:px-12">
         <div className="text-left mb-12">
           <h2 className="text-brand-primary-dark text-3xl md:text-4xl font-extrabold mb-4">
-            De cartera vencida a <span className="text-brand-primary">dinero recuperado</span>
+            ¿Cómo recuperamos <span className="text-brand-primary">tu cartera?</span>
           </h2>
           <p className="font-adobe text-black mt-2 text-lg leading-5">
             Proceso probado con cientos de empresas B2B en 15 países de LATAM

--- a/src/ui/recupera/sections/PricingModel.tsx
+++ b/src/ui/recupera/sections/PricingModel.tsx
@@ -69,6 +69,10 @@ export const PricingModel = () => {
                 <CheckCircle className="h-5 w-5 text-brand-primary" />
                 <span className="font-semibold">Transparencia total</span>
               </div>
+              <div className="flex items-center gap-2 text-brand-primary-dark">
+                <CheckCircle className="h-5 w-5 text-brand-primary" />
+                <span className="font-semibold">85% de recupero promedio</span>
+              </div>
             </div>
           </div>
 

--- a/src/ui/recupera/sections/UseCases.tsx
+++ b/src/ui/recupera/sections/UseCases.tsx
@@ -8,12 +8,12 @@ const useCases = [
   },
   {
     title: 'Deudores que no responden',
-    description: 'Cuentas donde la comunicación se cortó pero la relación vale la pena preservar.',
+    description: 'Clientes que dejaron de responder. La publicación en DICOM reactiva la conversación.',
     icon: MessageCircleOff,
   },
   {
-    title: 'Montos altos',
-    description: 'Facturas donde el expertise humano marca la diferencia en recuperación.',
+    title: 'Facturas de alto valor sin gestión activa',
+    description: 'Cuando el monto justifica externalizar con especialistas que trabajan solo a contingencia.',
     icon: DollarSign,
   },
   {
@@ -29,7 +29,7 @@ export const UseCases = () => {
       <div className="max-w-[1280px] mx-auto px-4 md:px-12">
         <div className="text-left mb-12">
           <h2 className="text-brand-primary-dark text-3xl md:text-4xl font-extrabold mb-4">
-            ¿En qué casos <span className="text-brand-primary">funciona?</span>
+            ¿Tu empresa está en <span className="text-brand-primary">alguno de estos casos?</span>
           </h2>
         </div>
 


### PR DESCRIPTION
## Resumen

Alineación completa del copy de recupera.somossena.com con la campaña de Google Ads activa y optimizaciones SEO basadas en análisis de competidores.

### Cambios de copy
- **Hero:** H1 y subtítulo reflejan el RSA activo — modelo de contingencia + publicación DICOM
- **HowItWorks:** H2 en pregunta + pasos 2 y 3 con proceso específico (DICOM)
- **PricingModel:** agrega checkbox "85% de recupero promedio"
- **Credibility:** H2 actualizado + stat 85% descomentado + grid a 3 columnas
- **UseCases:** H2 en pregunta + copy específico en casos 2 y 3
- **FinalCTA:** H2 con timeline concreto ("Resultado en 48h")
- **ContactForm:** H2 alineado a Recupera (no a la plataforma Sena)
- **Header:** "Servicio de Recupero" → "Recupera"

### SEO
- Title, description y keywords alineados con campaña activa + "facturas impagas"
- Locale corregido de es_PE a es_CL
- FAQ JSON-LD schema para featured snippets

### AI
- Nuevo `src/app/llms.txt/route.ts` para AI assistants

## Work-item
Closes #69 (getsena/sena-agents) — tasks #71, #72, #73, #74

## Test plan
- [ ] H1 correcto en mobile y desktop
- [ ] Stat 85% visible en sección Credibility
- [ ] `recupera.somossena.com/llms.txt` accesible tras deploy
- [ ] FAQ schema válido en Google Rich Results Test
- [ ] Title tag y meta description correctos en view-source