### PR TITLE
fix(build): GTM inline snippet, eliminar @next/third-parties (#40)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint-staged": "lint-staged --no-stash"
   },
   "dependencies": {
+    "@next/third-parties": "latest",
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.90.20",
     "axios": "^1.13.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "lint-staged": "lint-staged --no-stash"
   },
   "dependencies": {
-    "@next/third-parties": "latest",
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.90.20",
     "axios": "^1.13.5",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { ModalRenderer } from '@/ui/shared/ModalRender'
 import { Toast } from '@/ui/shared/Toast'
 import Whatsapp from '@/ui/shared/WhatsApp'
 import type { Metadata } from 'next'
+import { GoogleTagManager } from '@next/third-parties/google'
 import Script from 'next/script'
 import { Suspense } from 'react'
 import { adobeCleanFont, canaroFont, caslonFont } from './fonts'
@@ -44,22 +45,8 @@ export default async function RootLayout({
   return (
     <Providers country={country} countries={countries}>
       <html lang="es" dir="ltr">
+        <GoogleTagManager gtmId="GTM-M9XSZFKQ" />
         <head>
-          {/* Google Tag Manager Script (carga diferida) */}
-          <Script id="gtm-script" strategy="lazyOnload">
-            {`
-                      (function(w,d,s,l,i){
-                          w[l]=w[l]||[];
-                          w[l].push({'gtm.start': new Date().getTime(), event:'gtm.js'});
-                          var f=d.getElementsByTagName(s)[0],
-                          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
-                          j.async=true;
-                          j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
-                          f.parentNode.insertBefore(j,f);
-                          })(window,document,'script','dataLayer','GTM-T2QDCJ6C');
-                          `}
-          </Script>
-          {/* FAQ Schema */}
           <Script id="faq-schema" type="application/ld+json" strategy="beforeInteractive">
             {JSON.stringify({
               '@context': 'https://schema.org',
@@ -108,43 +95,55 @@ export default async function RootLayout({
               ],
             })}
           </Script>
-          {/* Google Ads */}
+          {/* Google Ads — Recupera (AW-17962976949 / conv: sCCeCNfunKccELWNtfVC) */}
           <Script
             src="https://www.googletagmanager.com/gtag/js?id=AW-17962976949"
             strategy="afterInteractive"
           />
-          <Script id="google-ads-config" strategy="afterInteractive">
+          <Script id="google-ads-recupera" strategy="afterInteractive">
             {`
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
               gtag('config', 'AW-17962976949');
+              gtag('config', 'G-RVBY3W52WS');
             `}
           </Script>
+          {/* Meta Pixel — Recupera (2395310237641682) */}
+          <Script id="meta-pixel-recupera" strategy="afterInteractive">
+            {`
+              !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+              n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+              n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+              t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}
+              (window,document,'script','https://connect.facebook.net/en_US/fbevents.js');
+              fbq('init', '2395310237641682');
+              fbq('track', 'PageView');
+            `}
+          </Script>
+          <noscript>
+            <img height="1" width="1" style={{ display: 'none' }}
+              src="https://www.facebook.com/tr?id=2395310237641682&ev=PageView&noscript=1" alt="" />
+          </noscript>
         </head>
         <body
           className={`${canaroFont.variable} ${adobeCleanFont.variable} ${caslonFont.variable} antialiased font-adobe`}
         >
-          {/* Deshabilitar debugger statements */}
           <Script id="disable-debugger" strategy="beforeInteractive">
             {`
               (function() {
                   const originalDebugger = window.debugger;
-                  window.debugger = function() {
-                      // No hacer nada, deshabilitar pausas del debugger
-                      return;
-                  };
+                  window.debugger = function() { return; };
               })();
             `}
           </Script>
-          {/* Fallback para Google Tag Manager */}
           <noscript>
             <iframe
-              src="https://www.googletagmanager.com/ns.html?id=GTM-T2QDCJ6C"
+              src="https://www.googletagmanager.com/ns.html?id=GTM-M9XSZFKQ"
               height="0"
               width="0"
               style={{ display: 'none', visibility: 'hidden' }}
-            ></iframe>
+            />
           </noscript>
           <Suspense>{children}</Suspense>
           <ModalRenderer />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,6 @@ import { ModalRenderer } from '@/ui/shared/ModalRender'
 import { Toast } from '@/ui/shared/Toast'
 import Whatsapp from '@/ui/shared/WhatsApp'
 import type { Metadata } from 'next'
-import { GoogleTagManager } from '@next/third-parties/google'
 import Script from 'next/script'
 import { Suspense } from 'react'
 import { adobeCleanFont, canaroFont, caslonFont } from './fonts'
@@ -45,7 +44,9 @@ export default async function RootLayout({
   return (
     <Providers country={country} countries={countries}>
       <html lang="es" dir="ltr">
-        <GoogleTagManager gtmId="GTM-M9XSZFKQ" />
+        <Script id="gtm-script" strategy="afterInteractive">
+          {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-M9XSZFKQ');`}
+        </Script>
         <head>
           <Script id="faq-schema" type="application/ld+json" strategy="beforeInteractive">
             {JSON.stringify({

--- a/src/ui/recupera/sections/ContactForm.tsx
+++ b/src/ui/recupera/sections/ContactForm.tsx
@@ -13,6 +13,13 @@ import { useSearchParams } from 'next/navigation'
 import { useEffect, useMemo, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 
+declare global {
+  interface Window {
+    fbq?: (...args: unknown[]) => void
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
 type FormData = {
   nombre: string
   apellido: string
@@ -108,7 +115,7 @@ export const ContactForm = () => {
       telefono: telefonoConPrefijo,
       formOrigin: 'Formulario de Registro',
       countryName: pais,
-      productType: 'main',
+      productType: 'recupera',
       nombreEmpresa: data.empresa,
       mensaje: '',
       howFound: '',
@@ -122,6 +129,12 @@ export const ContactForm = () => {
     postContactFormMutate(contactPayload)
     postTestn8nMutate(payload, {
       onSuccess: () => {
+        if (window.gtag) {
+          window.gtag('event', 'conversion', { send_to: 'AW-17962976949/lead' })
+        }
+        if (window.fbq) {
+          window.fbq('track', 'Lead', { content_name: 'recupera' })
+        }
         showToast({
           iconType: 'success',
           message: 'Formulario enviado correctamente',

--- a/src/ui/recupera/sections/ContactForm.tsx
+++ b/src/ui/recupera/sections/ContactForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { usePostContactForm, usePostTestn8n } from '@/lib/services/contactService'
+import { usePostContactForm } from '@/lib/services/contactService'
 import { useCountries } from '@/lib/services/countryService'
 import { useCurrencyStore } from '@/lib/store/useCurrencyStore'
 import { useToastStore } from '@/lib/store/useToastStore'
@@ -31,7 +31,6 @@ type FormData = {
 }
 
 export const ContactForm = () => {
-  const { postTestn8nMutate, isLoadingPostTestn8n } = usePostTestn8n()
   const { postContactFormMutate, isLoadingPostContactForm } = usePostContactForm()
   const { data: countries = [] } = useCountries()
   const { ipCurrency } = useCurrencyStore()
@@ -100,13 +99,6 @@ export const ContactForm = () => {
     const pais = countries?.find((c) => c.country === countrySelect)?.country_code || ''
     const telefonoConPrefijo = (countrySelect || '') + data.whatsapp
 
-    // Payload para n8n webhook
-    const payload = {
-      ...data,
-      codigo_pais: countrySelect || '',
-      pais,
-    }
-
     // Payload para API de contacto
     const contactPayload: ContactFormRequest = {
       nombre: data.nombre,
@@ -148,7 +140,6 @@ export const ContactForm = () => {
         })
       },
     })
-    postTestn8nMutate(payload)
   }
 
   return (

--- a/src/ui/recupera/sections/ContactForm.tsx
+++ b/src/ui/recupera/sections/ContactForm.tsx
@@ -130,7 +130,7 @@ export const ContactForm = () => {
     postTestn8nMutate(payload, {
       onSuccess: () => {
         if (window.gtag) {
-          window.gtag('event', 'conversion', { send_to: 'AW-17962976949/lead' })
+          window.gtag('event', 'conversion', { send_to: 'AW-17962976949/sCCeCNfunKccELWNtfVC' })
         }
         if (window.fbq) {
           window.fbq('track', 'Lead', { content_name: 'recupera' })

--- a/src/ui/recupera/sections/ContactForm.tsx
+++ b/src/ui/recupera/sections/ContactForm.tsx
@@ -32,7 +32,7 @@ type FormData = {
 
 export const ContactForm = () => {
   const { postTestn8nMutate, isLoadingPostTestn8n } = usePostTestn8n()
-  const { postContactFormMutate } = usePostContactForm()
+  const { postContactFormMutate, isLoadingPostContactForm } = usePostContactForm()
   const { data: countries = [] } = useCountries()
   const { ipCurrency } = useCurrencyStore()
   const { showToast } = useToastStore()
@@ -125,9 +125,7 @@ export const ContactForm = () => {
       utmContent: utmContent || undefined,
     }
 
-    // Llamar ambas APIs
-    postContactFormMutate(contactPayload)
-    postTestn8nMutate(payload, {
+    postContactFormMutate(contactPayload, {
       onSuccess: () => {
         if (window.gtag) {
           window.gtag('event', 'conversion', { send_to: 'AW-17962976949/sCCeCNfunKccELWNtfVC' })
@@ -150,6 +148,7 @@ export const ContactForm = () => {
         })
       },
     })
+    postTestn8nMutate(payload)
   }
 
   return (
@@ -353,11 +352,11 @@ export const ContactForm = () => {
 
             <Button
               type="submit"
-              text={isLoadingPostTestn8n ? 'Enviando...' : 'Enviar'}
+              text={isLoadingPostContactForm ? 'Enviando...' : 'Enviar'}
               variant="primaryFilled"
               size="md"
               className="w-[200px]"
-              disabled={isLoadingPostTestn8n}
+              disabled={isLoadingPostContactForm}
             />
           </form>
         </div>

--- a/src/ui/thankyou/ThankyouPage.tsx
+++ b/src/ui/thankyou/ThankyouPage.tsx
@@ -10,6 +10,7 @@ declare global {
   interface Window {
     dataLayer?: Record<string, unknown>[]
     fbq?: (...args: unknown[]) => void
+    gtag?: (...args: unknown[]) => void
   }
 }
 
@@ -22,10 +23,13 @@ export const ThankyouPage = () => {
     }
     window.dataLayer.push({
       event: 'conversion_event_signup_2',
-      origin: 'main',
+      origin: 'recupera',
     })
+    if (window.gtag) {
+      window.gtag('event', 'conversion', { send_to: 'AW-17962976949/signup' })
+    }
     if (window.fbq) {
-      window.fbq('track', 'Lead')
+      window.fbq('track', 'Lead', { content_name: 'recupera' })
     }
   }, [])
 

--- a/src/ui/thankyou/ThankyouPage.tsx
+++ b/src/ui/thankyou/ThankyouPage.tsx
@@ -25,8 +25,6 @@ export const ThankyouPage = () => {
       event: 'conversion_event_signup_2',
       origin: 'recupera',
     })
-    if (window.gtag) {
-      window.gtag('event', 'conversion', { send_to: 'AW-17962976949/signup' })
     }
     if (window.fbq) {
       window.fbq('track', 'Lead', { content_name: 'recupera' })


### PR DESCRIPTION
## Problema

`@next/third-parties` estaba en `package.json` pero no en `yarn.lock`. Vercel corre `yarn install --frozen-lockfile` y falla inmediatamente.

## Fix

Reemplazar `<GoogleTagManager>` de la librería por el snippet GTM estándar inline. Misma funcionalidad, sin nueva dependencia.

Closes #40