### PR TITLE
fix(build): GTM inline, eliminar @next/third-parties — Recupera (#40)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "lint-staged": "lint-staged --no-stash"
   },
   "dependencies": {
-    "@next/third-parties": "latest",
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.90.20",
     "axios": "^1.13.5",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,6 @@ import { ModalRenderer } from '@/ui/shared/ModalRender'
 import { Toast } from '@/ui/shared/Toast'
 import Whatsapp from '@/ui/shared/WhatsApp'
 import type { Metadata } from 'next'
-import { GoogleTagManager } from '@next/third-parties/google'
 import Script from 'next/script'
 import { Suspense } from 'react'
 import { adobeCleanFont, canaroFont, caslonFont } from './fonts'
@@ -45,7 +44,9 @@ export default async function RootLayout({
   return (
     <Providers country={country} countries={countries}>
       <html lang="es" dir="ltr">
-        <GoogleTagManager gtmId="GTM-M9XSZFKQ" />
+        <Script id="gtm-script" strategy="afterInteractive">
+          {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-M9XSZFKQ');`}
+        </Script>
         <head>
           <Script id="faq-schema" type="application/ld+json" strategy="beforeInteractive">
             {JSON.stringify({


### PR DESCRIPTION
Fixes build failure. @next/third-parties faltaba en yarn.lock. GTM inline directo, sin nueva dependencia. Closes #40