### PR TITLE
fix(build): syntax error ThankyouPage — extra } rompe build Vercel

### DIFF
--- a/src/ui/thankyou/ThankyouPage.tsx
+++ b/src/ui/thankyou/ThankyouPage.tsx
@@ -25,7 +25,6 @@ export const ThankyouPage = () => {
       event: 'conversion_event_signup_2',
       origin: 'recupera',
     })
-    }
     if (window.fbq) {
       window.fbq('track', 'Lead', { content_name: 'recupera' })
     }


### PR DESCRIPTION
## Problema

`ThankyouPage.tsx` tenía un `}` de más en el `useEffect` que cerraba la función prematuramente. Vercel fallaba con: `Parsing ecmascript source code failed — Expected ',', got 'if'`.

## Cambio

Eliminado el `}` sobrante. El flujo correcto ahora es:

```tsx
window.dataLayer.push({ event: 'conversion_event_signup_2', origin: 'recupera' })
if (window.fbq) {
  window.fbq('track', 'Lead', { content_name: 'recupera' })
}
```

## Impacto

Todos los deploys a producción han estado fallando desde PR #11. Este fix desbloquea el deploy de tracking.

Closes #40