### PR TITLE
fix(seo): metadataBase + twitter card + footer products + noindex thankyou

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,14 @@ export const metadata: Metadata = {
     'cobranza online, cobrar facturas vencidas, facturas impagas, cobranza b2b chile, publicacion dicom, recuperar cartera vencida, externalizar cobranza b2b, servicio de cobranza empresas',
   authors: [{ name: 'Recupera' }],
   robots: { index: true, follow: true },
+  metadataBase: new URL('https://recupera.somossena.com'),
+  alternates: { canonical: '/' },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Recupera - Cobranza B2B | Pagas Solo Si Recuperamos',
+    description: 'Solo pagas si recuperamos. Cobranza B2B con publicación DICOM en Chile. 85% de recupero promedio.',
+    images: ['https://recupera.somossena.com/sena-crm-lite.jpg'],
+  },
   openGraph: {
     title: 'Recupera - Cobranza B2B | Pagas Solo Si Recuperamos',
     description:

--- a/src/app/thankyou/page.tsx
+++ b/src/app/thankyou/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from 'next'
 import { ThankyouPage } from '@/ui/thankyou/ThankyouPage'
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
 
 const Thankyou = () => {
   return <ThankyouPage />

--- a/src/lib/data/constants.ts
+++ b/src/lib/data/constants.ts
@@ -39,8 +39,20 @@ export const FOOTER_EMPRESA = [
 
 export const FOOTER_DESCUBRIR = [
   {
-    label: 'Productos',
-    href: `${SENA_BASE_URL}/#productos`,
+    label: 'Plataforma de autogestión',
+    href: 'https://www.somossena.com',
+    type: 'external' as const,
+    disabled: false,
+  },
+  {
+    label: 'Recupera',
+    href: 'https://recupera.somossena.com',
+    type: 'external' as const,
+    disabled: false,
+  },
+  {
+    label: 'Opera',
+    href: 'https://opera.somossena.com',
     type: 'external' as const,
     disabled: false,
   },


### PR DESCRIPTION
## Summary
- `metadataBase`, `alternates: canonical`, `twitter` card en layout.tsx
- Footer DESCUBRIR: reemplaza link genérico "Productos" por los 3 productos con URL directa (Plataforma, Recupera, Opera)
- `/thankyou`: `robots: noindex, nofollow` — evita que Google indexe la página de confirmación

🤖 Generated with [Claude Code](https://claude.com/claude-code)