### PR TITLE
fix(cleanup): eliminar dead code N8N y WhatsApp duplicado

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import { getCountriesServer } from '@/lib/services/countryService.server'
 import { getIpInfoServer } from '@/lib/services/ipConfigService.server'
 import { ModalRenderer } from '@/ui/shared/ModalRender'
 import { Toast } from '@/ui/shared/Toast'
-import Whatsapp from '@/ui/shared/WhatsApp'
 import type { Metadata } from 'next'
 import Script from 'next/script'
 import { Suspense } from 'react'
@@ -157,7 +156,6 @@ export default async function RootLayout({
           <Suspense>{children}</Suspense>
           <ModalRenderer />
           <Toast />
-          <Whatsapp message="Hola, vi su web y quiero saber más sobre Recupera y cómo funciona." animated />
         </body>
       </html>
     </Providers>

--- a/src/lib/services/contactService.ts
+++ b/src/lib/services/contactService.ts
@@ -17,19 +17,3 @@ export const usePostContactForm = () => {
     isLoadingPostContactForm,
   }
 }
-
-const postTestn8n = async (data: any) => {
-  const res = await api.post('https://n8n.somossena.com/webhook/leads', data)
-  return res.data
-}
-
-export const usePostTestn8n = () => {
-  const { mutate: postTestn8nMutate, isPending: isLoadingPostTestn8n } = useMutation({
-    mutationFn: (data: any) => postTestn8n(data),
-  })
-
-  return {
-    postTestn8nMutate,
-    isLoadingPostTestn8n,
-  }
-}


### PR DESCRIPTION
## Summary
- **Elimina `postTestn8n`/`usePostTestn8n`** de `contactService.ts`
- **Remueve `<Whatsapp>` de `layout.tsx`** — estaba duplicado con el de `RecuperaPage.tsx`. El de `RecuperaPage.tsx` tiene el mensaje correcto ("quiero información sobre Recupera para gestionar mi cartera vencida") y se conserva.

🤖 Generated with [Claude Code](https://claude.com/claude-code)