### PR TITLE
fix(lead): mapOrigen 'true' → 'Meta' + PRODUCT_LIST_ID 363 → 218

### DIFF
--- a/src/app/api/lead/route.ts
+++ b/src/app/api/lead/route.ts
@@ -21,7 +21,7 @@ type LeadPayload = {
 
 const HS_API = 'https://api.hubapi.com'
 const OWNER_FRANCISCO = '89319447'
-const PRODUCT_LIST_ID = '363'
+const PRODUCT_LIST_ID = '218'
 const INTERES_DEL_PRODUCTO = 'Recupero Plus'
 
 function mapOrigen(utmSource?: string): string {

--- a/src/app/api/lead/route.ts
+++ b/src/app/api/lead/route.ts
@@ -27,7 +27,7 @@ const INTERES_DEL_PRODUCTO = 'Recupero Plus'
 function mapOrigen(utmSource?: string): string {
   const src = (utmSource ?? '').toLowerCase()
   if (src === 'google' || src === 'cpc') return 'Google'
-  if (src === 'facebook' || src === 'meta' || src === 'fb') return 'true'
+  if (src === 'facebook' || src === 'meta' || src === 'fb') return 'Meta'
   if (src === 'linkedin') return 'LinkedIn'
   return 'Orgánico'
 }


### PR DESCRIPTION
## Fixes incluidos

### 1. mapOrigen Meta: value 'true' → 'Meta'

```diff
- if (src === 'facebook' || src === 'meta' || src === 'fb') return 'true'
+ if (src === 'facebook' || src === 'meta' || src === 'fb') return 'Meta'
```

El enum `origen` en HubSpot fue corregido vía PATCH a la Properties API. Este PR alinea el código.

### 2. PRODUCT_LIST_ID 363 → 218

```diff
- const PRODUCT_LIST_ID = '363'
+ const PRODUCT_LIST_ID = '218'
```

El ID `363` no existe en HubSpot. La lista correcta es la **#218 "Sena - Leads Recupera"**. Los contactos se agregaban a una lista inexistente sin error visible.

## Test plan

- [ ] Form con `?utm_source=meta` → contacto en HubSpot con `origen = "Meta"`
- [ ] Form con `?utm_source=google` → contacto con `origen = "Google"`
- [ ] Form sin UTMs → contacto con `origen = "Orgánico"`
- [ ] Nuevo contacto aparece en lista **#218 "Sena - Leads Recupera"**
- [ ] Deal creado y asociado al contacto

🤖 Generated with [Claude Code](https://claude.com/claude-code)