### PR TITLE
chore(tracking): eliminar GA4 inline — GTM gestiona G-RVBY3W52WS

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -114,7 +114,6 @@ export default async function RootLayout({
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
               gtag('config', 'AW-17962976949');
-              gtag('config', 'G-RVBY3W52WS');
             `}
           </Script>
           {/* Meta Pixel — Recupera (2395310237641682) */}


### PR DESCRIPTION
GTM-M9XSZFKQ configurado vía API con tag GA4 Configuration → G-RVBY3W52WS → All Pages. Elimina gtag('config', 'G-RVBY3W52WS') inline del layout.