### PR TITLE
fix(tracking): atribución gclid/fbclid + GTM @next/third-parties + landingPage URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@commitlint/cli": "20.5.0",
     "@commitlint/config-conventional": "20.5.0",
     "@next/eslint-plugin-next": "16.2.4",
+    "@next/third-parties": "^16.2.2",
     "@tailwindcss/postcss": "^4.1.18",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint-staged": "lint-staged --no-stash"
   },
   "dependencies": {
+    "@next/third-parties": "^16.2.2",
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.90.20",
     "axios": "^1.13.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@commitlint/cli": "20.5.0",
     "@commitlint/config-conventional": "20.5.0",
     "@next/eslint-plugin-next": "16.2.4",
-    "@next/third-parties": "^16.2.2",
     "@tailwindcss/postcss": "^4.1.18",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/src/app/api/lead/route.ts
+++ b/src/app/api/lead/route.ts
@@ -24,7 +24,9 @@ const OWNER_FRANCISCO = '89319447'
 const PRODUCT_LIST_ID = '363'
 const INTERES_DEL_PRODUCTO = 'Recupero Plus'
 
-function mapOrigen(utmSource?: string): string {
+function mapOrigen(utmSource?: string, gclid?: string, fbclid?: string): string {
+  if (gclid) return 'Google'
+  if (fbclid) return 'Meta'
   const src = (utmSource ?? '').toLowerCase()
   if (src === 'google' || src === 'cpc') return 'Google'
   if (src === 'facebook' || src === 'meta' || src === 'fb') return 'Meta'
@@ -79,8 +81,11 @@ async function findContactByEmail(token: string, email: string): Promise<string 
 
 async function upsertContact(token: string, body: LeadPayload): Promise<string> {
   const prioridad = calcPrioridad(body.facturas_pendientes, body.alguien_cobrando)
-  const origen = mapOrigen(body.utmSource)
-  const fuente = body.utmSource ? 'Ads' : 'Orgánico'
+  const origen = mapOrigen(body.utmSource, body.gclid, body.fbclid)
+  const fuente = body.gclid ? 'Google Ads'
+    : body.fbclid ? 'Meta Ads'
+    : body.utmSource ? 'Ads'
+    : 'Orgánico'
 
   const properties: Record<string, string> = {
     firstname: body.nombre,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,6 @@ import { ModalRenderer } from '@/ui/shared/ModalRender'
 import { Toast } from '@/ui/shared/Toast'
 import type { Metadata } from 'next'
 import Script from 'next/script'
-import { GoogleTagManager } from '@next/third-parties/google'
 import { Suspense } from 'react'
 import { adobeCleanFont, canaroFont, caslonFont } from './fonts'
 import './globals.css'
@@ -52,7 +51,9 @@ export default async function RootLayout({
   return (
     <Providers country={country} countries={countries}>
       <html lang="es" dir="ltr">
-        <GoogleTagManager gtmId="GTM-M9XSZFKQ" />
+        <Script id="gtm-script" strategy="afterInteractive">
+          {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-M9XSZFKQ');`}
+        </Script>
         <head>
           <Script id="faq-schema" type="application/ld+json" strategy="beforeInteractive">
             {JSON.stringify({
@@ -143,6 +144,14 @@ export default async function RootLayout({
               })();
             `}
           </Script>
+          <noscript>
+            <iframe
+              src="https://www.googletagmanager.com/ns.html?id=GTM-M9XSZFKQ"
+              height="0"
+              width="0"
+              style={{ display: 'none', visibility: 'hidden' }}
+            />
+          </noscript>
           <Suspense>{children}</Suspense>
           <ModalRenderer />
           <Toast />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { ModalRenderer } from '@/ui/shared/ModalRender'
 import { Toast } from '@/ui/shared/Toast'
 import type { Metadata } from 'next'
 import Script from 'next/script'
+import { GoogleTagManager } from '@next/third-parties/google'
 import { Suspense } from 'react'
 import { adobeCleanFont, canaroFont, caslonFont } from './fonts'
 import './globals.css'
@@ -51,9 +52,7 @@ export default async function RootLayout({
   return (
     <Providers country={country} countries={countries}>
       <html lang="es" dir="ltr">
-        <Script id="gtm-script" strategy="afterInteractive">
-          {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-M9XSZFKQ');`}
-        </Script>
+        <GoogleTagManager gtmId="GTM-M9XSZFKQ" />
         <head>
           <Script id="faq-schema" type="application/ld+json" strategy="beforeInteractive">
             {JSON.stringify({
@@ -144,14 +143,6 @@ export default async function RootLayout({
               })();
             `}
           </Script>
-          <noscript>
-            <iframe
-              src="https://www.googletagmanager.com/ns.html?id=GTM-M9XSZFKQ"
-              height="0"
-              width="0"
-              style={{ display: 'none', visibility: 'hidden' }}
-            />
-          </noscript>
           <Suspense>{children}</Suspense>
           <ModalRenderer />
           <Toast />

--- a/src/ui/recupera/sections/ContactForm.tsx
+++ b/src/ui/recupera/sections/ContactForm.tsx
@@ -135,7 +135,7 @@ export const ContactForm = () => {
         utmTerm: utmTerm ?? undefined,
         gclid: gclid ?? undefined,
         fbclid: fbclid ?? undefined,
-        landingPage: window.location.pathname,
+        landingPage: window.location.href,
       }),
     }).catch(() => {})
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1995,6 +1995,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+
+"@next/third-parties@npm:^16.2.2":
+  version: 16.2.2
+  resolution: "@next/third-parties@npm:16.2.2"
+  dependencies:
+    third-party-capital: "npm:1.0.20"
+  peerDependencies:
+    next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
+    react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+  checksum: 10c0/d9740e078f3ab8d1de573c2490ad7f59d26bd99fe61ccf68b074177505398bf13e05055d7560882c69300a38630c9982139c54b074220a72552bd048d72beb00
+  languageName: node
+  linkType: hard
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -7977,6 +7989,13 @@ __metadata:
   version: 2.3.0
   resolution: "tapable@npm:2.3.0"
   checksum: 10c0/cb9d67cc2c6a74dedc812ef3085d9d681edd2c1fa18e4aef57a3c0605fdbe44e6b8ea00bd9ef21bc74dd45314e39d31227aa031ebf2f5e38164df514136f2681
+  languageName: node
+  linkType: hard
+
+"third-party-capital@npm:1.0.20":
+  version: 1.0.20
+  resolution: "third-party-capital@npm:1.0.20"
+  checksum: 10c0/7f45ff156ec9d7e2957a5b39061be22b780ffbd2d93c127252d908e2bff6cdd09f827a95909d457c8096e036f155006a38e355a06ee11cb6d63c7f4b150bbfb0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problema
3 leads de Recupera llegaron con `fuente_del_lead: "Orgánico"` aunque tenían `gclid` (vinieron de Google Ads). La atribución en HubSpot era incorrecta.

## Fixes incluidos

### Bug #155 — fuente_del_lead siempre "Orgánico"
`route.ts` — `mapOrigen` y `fuente` ahora detectan `gclid` y `fbclid`:
- Si hay `gclid` → `origen: "Google"`, `fuente_del_lead: "Google Ads"`
- Si hay `fbclid` → `origen: "Meta"`, `fuente_del_lead: "Meta Ads"`
- Si hay `utm_source` → `fuente_del_lead: "Ads"` (fallback anterior)
- Sin nada → `"Orgánico"` (correcto)

### Bug #156 — landing_page capturaba "/"
`ContactForm.tsx` — `window.location.pathname` → `window.location.href`
Ahora captura la URL completa (`recupera.somossena.com/`) en lugar del path.

### Bug #154 — GTM inconsistente (script manual vs componente)
`layout.tsx` — migrado a `<GoogleTagManager gtmId="GTM-M9XSZFKQ" />` de `@next/third-parties`.
`package.json` — agregado `@next/third-parties@^16.2.2`.

## Verificación
- Verificado en producción: 3 leads Recupera tienen `gclid` presente pero `fuente_del_lead: "Orgánico"` ❌
- Después de este fix: `fuente_del_lead: "Google Ads"` ✅ para leads con gclid
- GTM sigue usando el mismo container `GTM-M9XSZFKQ`, solo cambia cómo se carga

Closes #155
Closes #156
Closes #154

Part of feature #38