### PR TITLE
fix(tracking): remover dataLayer type duplicado — conflicto con @next/third-parties

### DIFF
--- a/src/ui/thankyou/ThankyouPage.tsx
+++ b/src/ui/thankyou/ThankyouPage.tsx
@@ -8,7 +8,6 @@ import { useEffect } from 'react'
 
 declare global {
   interface Window {
-    dataLayer?: Record<string, unknown>[]
     fbq?: (...args: unknown[]) => void
     gtag?: (...args: unknown[]) => void
   }


### PR DESCRIPTION
## Problema
Build de Vercel falla con error TypeScript:

```
Type error: Subsequent property declarations must have the same type.
Property 'dataLayer' must be of type 'Object[] | undefined', but here has type 'Record<string, unknown>[] | undefined'.
```

`ThankyouPage.tsx` declaraba `dataLayer?: Record<string, unknown>[]` en la interfaz global `Window`.
Al agregar `@next/third-parties` (GoogleTagManager), ese paquete también declara `dataLayer` como `Object[]`.
TypeScript strict mode no permite declaraciones duplicadas con tipos diferentes.

## Fix
Remover la declaración de `dataLayer` de `ThankyouPage.tsx`. La declaración de `@next/third-parties` es suficiente.
El uso de `window.dataLayer` en el código sigue funcionando — `Object[]` es compatible con el push de eventos.

Part of feature #38