### PR TITLE
fix(ui): productos dropdown lista vertical — elimina efecto escalera

### DIFF
--- a/src/ui/layout/Header.tsx
+++ b/src/ui/layout/Header.tsx
@@ -627,16 +627,16 @@ export const Header = ({ variant }: Props) => {
                         </div>
 
                         <div className="col-span-8 p-6">
-                          <div className="grid grid-cols-3 gap-2">
+                          <div className="flex flex-col gap-1">
                             {products.map((it) => (
                               <button
                                 key={it.id}
                                 onClick={() => goToProduct(it.tab, it.href)}
-                                className="group text-left rounded-xl p-4 hover:bg-gray-50 transition cursor-pointer"
+                                className="group text-left rounded-xl p-3 hover:bg-gray-50 transition cursor-pointer"
                                 role="menuitem"
                               >
-                                <div className="flex items-start gap-3">
-                                  <div className="mt-0.5 h-8 w-8 shrink-0 rounded-lg bg-brand-primary/5 group-hover:bg-brand-primary/10 border border-brand-primary/10 flex items-center justify-center text-brand-primary transition-colors">
+                                <div className="flex items-center gap-3">
+                                  <div className="h-8 w-8 shrink-0 rounded-lg bg-brand-primary/5 group-hover:bg-brand-primary/10 border border-brand-primary/10 flex items-center justify-center text-brand-primary transition-colors">
                                     {it.tab === 'autogestion' ? (
                                       <svg
                                         width="16"


### PR DESCRIPTION
## Problema

El dropdown de Productos en desktop usaba `grid-cols-3` dentro de un `col-span-8` (≈450px), dejando ≈130px por tarjeta. "Plataforma de autogestión" forzaba wrap a 2 líneas mientras "Recupera" y "Opera" caben en 1, creando efecto de escalera.

## Solución

Cambio de `grid grid-cols-3 gap-2` a `flex flex-col gap-1`. Los 3 productos se muestran como lista vertical alineada, sin dependencia del ancho disponible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)