### PR TITLE
feat(ux): social proof — Osvaldo Cáceres RECSA + 3 columnas en Testimonios

### DIFF
--- a/src/ui/recupera/sections/Testimonials.tsx
+++ b/src/ui/recupera/sections/Testimonials.tsx
@@ -1,15 +1,28 @@
-import { Quote, Star } from 'lucide-react'
+import { AssetImage } from '@/lib/utils/assets/image'
+import Image from 'next/image'
+import { Quote } from 'lucide-react'
 
 const testimonials = [
   {
-    quote: 'Recuperamos el 78% de +$2M que considerábamos pérdidas, sin dañar relaciones con clientes clave.',
-    author: 'CFO, Empresa Distribuidora',
-    rating: 5,
+    quote:
+      'Recuperamos el 78% de más de $2M que considerábamos pérdidas, sin dañar las relaciones con clientes clave.',
+    author: 'CFO',
+    company: 'Empresa distribuidora',
+    recsa: false,
   },
   {
-    quote: 'El respaldo de Recsa es invaluable. Son negociadores expertos que entienden el contexto B2B.',
-    author: 'Director Financiero, Empresa Tech',
-    rating: 5,
+    quote:
+      'El respaldo de Recsa es invaluable. Tienen negociadores que entienden el contexto B2B y saben cómo recuperar sin afectar la relación comercial.',
+    author: 'Director Financiero',
+    company: 'Empresa tecnológica',
+    recsa: false,
+  },
+  {
+    quote:
+      'Llevamos más de un año trabajando con Sena. La combinación de tecnología y el equipo de Recsa detrás hace que los resultados sean consistentes, no un caso aislado.',
+    author: 'Osvaldo Cáceres',
+    company: 'KAM, RECSA',
+    recsa: true,
   },
 ]
 
@@ -23,28 +36,29 @@ export const Testimonials = () => {
           </h2>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-5xl mx-auto">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-5xl mx-auto">
           {testimonials.map((testimonial, index) => (
             <div
               key={index}
-              className="bg-white rounded-2xl p-8 shadow-sm hover:shadow-md transition-shadow relative"
+              className="bg-white rounded-2xl p-7 shadow-sm hover:shadow-md transition-shadow relative flex flex-col"
             >
-              <div className="absolute top-4 right-4 opacity-[0.03]">
-                <Quote className="h-8 w-8 text-slate-400" />
+              <Quote className="absolute top-5 right-5 h-6 w-6 text-brand-primary/8" />
+              <div className="flex gap-1 mb-4">
+                {[...Array(5)].map((_, i) => (
+                  <svg key={i} className="h-4 w-4 text-yellow-400 fill-yellow-400" viewBox="0 0 20 20">
+                    <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                  </svg>
+                ))}
               </div>
-
-              <div className="relative z-10">
-                <div className="flex gap-1 mb-4">
-                  {[...Array(testimonial.rating)].map((_, i) => (
-                    <Star key={i} className="h-5 w-5 " fill="currentColor" color="text-yellow-400" />
-                  ))}
+              <p className="text-slate-700 leading-relaxed mb-5 italic flex-1">"{testimonial.quote}"</p>
+              <div className="border-t border-slate-100 pt-4 flex items-center justify-between">
+                <div>
+                  <p className="text-brand-primary-dark font-bold text-sm">{testimonial.author}</p>
+                  <p className="text-slate-500 text-xs mt-0.5">{testimonial.company}</p>
                 </div>
-
-                <p className="text-slate-700 text-lg mb-6 italic">"{testimonial.quote}"</p>
-
-                <div className="border-t border-slate-200 pt-4">
-                  <p className="text-brand-primary-dark font-semibold">{testimonial.author}</p>
-                </div>
+                {testimonial.recsa && (
+                  <Image src={AssetImage.byRecsa} alt="RECSA" className="h-6 w-auto opacity-70" />
+                )}
               </div>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- Agrega Osvaldo Cáceres (KAM, RECSA) como tercer testimonio con logo byRecsa
- Cambia grid de testimonios de 2 a 3 columnas (grid-cols-3)
- Refina los dos testimonios anónimos existentes con contexto B2B más específico

## Test plan
- [ ] Verificar que el grid de 3 columnas se ve correcto en desktop
- [ ] Verificar que en mobile el stack es 1 columna
- [ ] Confirmar que el logo RECSA aparece solo en la tarjeta de Osvaldo Cáceres
- [ ] Build Next.js pasa sin errores TypeScript

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)