### PR TITLE
fix(api): HubSpot addToList silent failure + 409 race condition

### DIFF
--- a/src/app/api/lead/route.ts
+++ b/src/app/api/lead/route.ts
@@ -129,6 +129,15 @@ async function upsertContact(token: string, body: LeadPayload): Promise<string> 
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify({ properties }),
   })
+  if (res.status === 409) {
+    // Contact exists but findContactByEmail missed it (race/transient error) — recover the ID
+    const errData = (await res.json().catch(() => ({}))) as Record<string, unknown>
+    const conflictId = (errData.id as string) || (errData.data as Record<string, string>)?.existingObjectId
+    if (conflictId) return conflictId
+    const fallback = await findContactByEmail(token, body.email)
+    if (fallback) return fallback
+    throw new Error(`POST contact 409 conflict, ID not recoverable`)
+  }
   if (!res.ok) {
     const err = await res.json().catch(() => ({}))
     throw new Error(`POST contact failed: ${JSON.stringify(err)}`)
@@ -167,11 +176,15 @@ async function createDeal(token: string, contactId: string, body: LeadPayload): 
 }
 
 async function addToList(token: string, contactId: string): Promise<void> {
-  await fetch(`${HS_API}/crm/v3/lists/${PRODUCT_LIST_ID}/memberships/add`, {
+  const res = await fetch(`${HS_API}/crm/v3/lists/${PRODUCT_LIST_ID}/memberships/add`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify([contactId]),
   })
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok || (data as { recordIdsMissing?: string[] }).recordIdsMissing?.length) {
+    throw new Error(`addToList failed for contact ${contactId}: ${JSON.stringify(data)}`)
+  }
 }
 
 async function sendMetaCapi(body: LeadPayload): Promise<void> {

--- a/src/ui/thankyou/ThankyouPage.tsx
+++ b/src/ui/thankyou/ThankyouPage.tsx
@@ -115,7 +115,7 @@ export const ThankyouPage = () => {
               <div className="flex flex-col items-center gap-3 mt-6 pt-6 border-t border-slate-100">
                 <p className="text-slate-500 text-sm">¿Tienes dudas? Habla con nuestro agente</p>
                 <Link
-                  href="https://wa.me/56977290160?text=Hola%2C+me+registr%C3%A9+en+Recupera+y+tengo+una+consulta+sobre+el+servicio"
+                  href="https://wa.me/56977290160?text=Hola%2C+acabo+de+registrarme+en+Recupera.+Quiero+saber+c%C3%B3mo+funciona+para+mi+cartera+de+facturas."
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-2.5 bg-[#25D366] hover:bg-[#1da851] text-white font-bold text-sm px-5 py-3 rounded-full transition-all duration-200 hover:shadow-lg hover:shadow-[#25D366]/25 hover:scale-[1.02]"


### PR DESCRIPTION
## Summary

- `addToList` ahora verifica `res.ok` y `data.recordIdsMissing` — HubSpot retorna HTTP 200 incluso cuando falla la adición a la lista; el código previo no detectaba ese caso
- `upsertContact` maneja 409 Conflict extrayendo el ID del cuerpo del error, cubriendo la race condition donde `findContactByEmail` retorna `null` justo antes de que otro proceso cree el contacto
- Mensaje WhatsApp de `/thankyou` actualizado a copy específico de Recupera

## Root cause del bug "lista pegada en 3 contactos"

Flujo que fallaba silenciosamente:
1. `findContactByEmail` retorna `null` (error transitorio de red o timing)
2. POST a `/crm/v3/objects/contacts` → HubSpot responde 409 (el contacto ya existía)
3. Código anterior: `throw new Error('POST contact failed')` → outer catch → `{ ok: true, warning: 'CRM sync pendiente' }`
4. `addToList` nunca se ejecuta → lead no entra a la lista 363

## Test plan

- [ ] Verificar que nuevos formularios en recupera.somossena.com agregan leads a lista HubSpot #363
- [ ] Verificar que la lista crece más allá de los 3 contactos actuales
- [ ] Confirmar que Vercel logs ya no muestran `CRM sync pendiente` sin un error real

🤖 Generated with [Claude Code](https://claude.com/claude-code)