### PR TITLE
fix(ui): eliminar referencias Recsa de hero, credibilidad, testimonios, faq y CTA

### DIFF
--- a/src/ui/recupera/sections/Credibility.tsx
+++ b/src/ui/recupera/sections/Credibility.tsx
@@ -32,7 +32,7 @@ export const Credibility = () => {
   return (
     <div id="credibilidad" className="bg-[#F9F9F9] py-12 md:py-20">
       <div className="max-w-[1280px] mx-auto px-4 md:px-12">
-        <div className="text-left mb-12">
+        {/* <div className="text-left mb-12">
           <h2 className="text-brand-primary-dark text-3xl md:text-4xl font-extrabold mb-4">
             Recsa: 40 años recuperando cartera en <span className="text-brand-primary">15 países</span>
           </h2>
@@ -59,7 +59,7 @@ export const Credibility = () => {
               </div>
             )
           })}
-        </div>
+        </div> */}
 
         {/* <div className="mt-12 text-center">
           <div className="inline-flex items-center gap-2 bg-white rounded-full px-6 py-3 shadow-sm">

--- a/src/ui/recupera/sections/FAQ.tsx
+++ b/src/ui/recupera/sections/FAQ.tsx
@@ -13,10 +13,10 @@ const faqs = [
     question: '¿Qué pasa si no recuperan nada?',
     answer: 'No pagas nada. Modelo 100% contingente.',
   },
-  {
-    question: '¿Se preservan las relaciones?',
-    answer: 'Nuestro enfoque profesional preserva vínculos comerciales. 40 años de experiencia Recsa.',
-  },
+  // {
+  //   question: '¿Se preservan las relaciones?',
+  //   answer: 'Nuestro enfoque profesional preserva vínculos comerciales. 40 años de experiencia Recsa.',
+  // },
   {
     question: '¿Trabajan solo cartera vencida?',
     answer: 'Sí, cartera +60 días vencida. Para cobranza preventiva, usa la plataforma Sena.',

--- a/src/ui/recupera/sections/FinalCTA.tsx
+++ b/src/ui/recupera/sections/FinalCTA.tsx
@@ -38,10 +38,10 @@ export const FinalCTA = () => {
               <div className="text-3xl font-extrabold text-brand-primary mb-2">$0</div>
               <div className="text-slate-600 text-sm font-medium">inicial</div>
             </div>
-            <div className="bg-white rounded-xl p-6 text-center border border-slate-200 shadow-sm">
+            {/* <div className="bg-white rounded-xl p-6 text-center border border-slate-200 shadow-sm">
               <div className="text-3xl font-extrabold text-brand-primary mb-2">40+</div>
               <div className="text-slate-600 text-sm font-medium">años Recsa</div>
-            </div>
+            </div> */}
           </div>
 
           <div className="mb-8">

--- a/src/ui/recupera/sections/Hero.tsx
+++ b/src/ui/recupera/sections/Hero.tsx
@@ -27,8 +27,7 @@ export const Hero = () => {
           </h1>
 
           <p className="text-black text-sm md:text-lg lg:text-xl mb-6 md:mb-8 mt-3 md:mt-4 max-w-3xl mx-auto leading-relaxed">
-            Empresa de cobranza B2B con publicación DICOM en Chile. Sin costo fijo, sin riesgo. Respaldados
-            por Recsa y 40 años de experiencia en LATAM.
+            Empresa de cobranza B2B con publicación DICOM en Chile. Sin costo fijo, sin riesgo.
           </p>
 
           <div className="flex flex-col md:flex-row gap-3 md:gap-4 justify-center max-w-md md:max-w-none mx-auto">
@@ -69,14 +68,14 @@ export const Hero = () => {
               Presencia LATAM
             </div>
           </div>
-          <div className="flex-1 p-3 md:p-8 text-center">
+          {/* <div className="flex-1 p-3 md:p-8 text-center">
             <div className="text-lg md:text-4xl font-extrabold text-brand-primary mb-0.5 md:mb-1">
               40+ años
             </div>
             <div className="text-slate-600 text-[9px] md:text-sm font-medium leading-tight">
               Experiencia Recsa
             </div>
-          </div>
+          </div> */}
         </div>
       </div>
     </div>

--- a/src/ui/recupera/sections/Testimonials.tsx
+++ b/src/ui/recupera/sections/Testimonials.tsx
@@ -7,7 +7,7 @@ const testimonials = [
     rating: 5,
   },
   {
-    quote: 'El respaldo de Recsa es invaluable. Son negociadores expertos que entienden el contexto B2B.',
+    quote: 'El respaldo de Sena es invaluable. Son negociadores expertos que entienden el contexto B2B.',
     author: 'Director Financiero, Empresa Tech',
     rating: 5,
   },


### PR DESCRIPTION
## Summary
- Hero: elimina "Respaldados por Recsa y 40 años de experiencia en LATAM." del subtítulo
- Hero stats bar: comenta card "40+ años / Experiencia Recsa"
- Credibility: comenta sección completa (título, descripción e indicadores de Recsa)
- Testimonials: reemplaza "El respaldo de Recsa" por "El respaldo de Sena"
- FAQ: comenta pregunta "¿Se preservan las relaciones?" con ref a Recsa
- FinalCTA: comenta card "40+ / años Recsa"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)