### PR TITLE
fix(lead): eliminar fail-open en /api/lead

### DIFF
--- a/src/app/api/lead/route.ts
+++ b/src/app/api/lead/route.ts
@@ -261,6 +261,9 @@ export async function POST(req: NextRequest) {
   } catch (err) {
     console.error('[HubSpot] error:', err instanceof Error ? err.message : 'CRM error')
     await capiPromise
-    return NextResponse.json({ ok: true, warning: 'CRM sync pendiente' })
+    return NextResponse.json(
+      { ok: false, error: 'No pudimos registrar tu solicitud. Intenta de nuevo.' },
+      { status: 502 }
+    )
   }
 }


### PR DESCRIPTION
## Summary
/api/lead ya no responde {ok:true} cuando HubSpot falla -- ahora 502 {ok:false}.

## Por que
Mismo hallazgo que en sena-landing (ver PR relacionado): fail-open silencioso en /api/lead detectado en sesion de diagnostico 2026-07-28. El form de recupera-landing (ContactForm.tsx) ya gatea su redirect/toast en una mutacion separada (postContactFormMutate), asi que no tenia el bug de conversiones fantasma -- pero el endpoint HubSpot igual debia dejar de mentir sobre el resultado real.

## Test plan
- [x] tsc --noEmit sin errores
- [x] next build completo sin errores

Generated with Claude Code